### PR TITLE
Update configurations, tests, and immutability checks in multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.vs/
 /vendor/
 /composer.lock
+/.phpunit.cache/
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,14 @@
             "src/Helpers.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "InitPHP\\HTTP\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    },
     "authors": [
         {
             "name": "Muhammet ŞAFAK",
@@ -26,5 +34,10 @@
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "php-http/psr7-integration-tests": "^1.3",
+        "http-interop/http-factory-tests": "^2.2"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="false"
+         failOnWarning="false"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="PSR-7 Integration">
+            <directory>tests/Psr7</directory>
+        </testsuite>
+        <testsuite name="PSR-17 Integration">
+            <directory>tests/Psr17</directory>
+        </testsuite>
+        <testsuite name="PSR-18 Integration">
+            <directory>tests/Psr18</directory>
+        </testsuite>
+        <testsuite name="Immutability">
+            <directory>tests/Immutability</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <const name="URI_FACTORY" value="InitPHP\HTTP\Factory\Factory"/>
+        <const name="STREAM_FACTORY" value="InitPHP\HTTP\Factory\Factory"/>
+        <const name="UPLOADED_FILE_FACTORY" value="InitPHP\HTTP\Factory\Factory"/>
+    </php>
+</phpunit>

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -204,7 +204,7 @@ class Client implements \Psr\Http\Client\ClientInterface
                 $options[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_1_1;
         }
 
-        if ($method === 'HEAD') {
+        if (\strtoupper($method) === 'HEAD') {
             $options[\CURLOPT_NOBODY] = true;
         } elseif ($body !== '') {
             $options[\CURLOPT_POSTFIELDS] = $body;

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -38,6 +38,24 @@ class Request implements \InitPHP\HTTP\Message\Interfaces\RequestInterface
 
     private static Request $requestImmutable;
 
+    /**
+     * PSR-7 immutability: clone'da body ve URI'yi de derinleştir; aksi halde
+     * `$cloned->getBody()->write(...)` veya `$cloned->getUri()->setHost(...)`
+     * orijinali mutasyona uğratır.
+     */
+    public function __clone()
+    {
+        if (isset($this->stream)) {
+            $this->stream = clone $this->stream;
+        }
+        if (isset($this->uri)) {
+            $this->uri = clone $this->uri;
+        }
+        if (isset($this->_objParameters)) {
+            $this->_objParameters = clone $this->_objParameters;
+        }
+    }
+
     public function __construct(string $method, $uri, array $headers = [], $body = null, string $version = '1.1')
     {
         if(!($uri instanceof UriInterface)) {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -109,6 +109,17 @@ class Response implements ResponseInterface
      * @param string $version
      * @param string|null $reason
      */
+    /**
+     * PSR-7 immutability: clone'da body'i de derinleştir ki
+     * `$cloned->getBody()->write(...)` orijinali bozmasın.
+     */
+    public function __clone()
+    {
+        if (isset($this->stream)) {
+            $this->stream = clone $this->stream;
+        }
+    }
+
     public function __construct(int $status = 200, array $headers = [], $body = null, string $version = '1.1', ?string $reason = null)
     {
         if(!in_array($version, ['1.0', '1.1', '2.0'], true)){

--- a/src/Message/ServerRequest.php
+++ b/src/Message/ServerRequest.php
@@ -43,6 +43,20 @@ class ServerRequest implements ServerRequestInterface
     protected array $uploadedFiles = [];
 
 
+    /**
+     * PSR-7 immutability: clone'da body + URI'yi derinleştir.
+     * uploadedFiles ve attributes ham PHP array'i; copy-on-write zaten kopyalar.
+     */
+    public function __clone()
+    {
+        if (isset($this->stream)) {
+            $this->stream = clone $this->stream;
+        }
+        if (isset($this->uri)) {
+            $this->uri = clone $this->uri;
+        }
+    }
+
     public function __construct(string $method, $uri, array $headers = [], $body = null, string $version = '1.1', array $serverParams = [])
     {
         $this->serverParams = $serverParams;

--- a/src/Message/Stream.php
+++ b/src/Message/Stream.php
@@ -135,6 +135,55 @@ class Stream implements StreamInterface
     }
 
     /**
+     * PSR-7 immutability: clone yapıldığında resource'u derinleştir; aksi halde
+     * iki Stream aynı resource handle'ını paylaşır, withBody dışı tüm withX
+     * çağrıları orijinal mesajın body'sini de değiştirir.
+     */
+    public function __clone()
+    {
+        if (!isset($this->stream)) {
+            return;
+        }
+        $this->uri = null;
+        if (is_string($this->stream)) {
+            // String backend zaten PHP copy-on-write; ek iş gerekmiyor.
+            return;
+        }
+        if (!is_resource($this->stream)) {
+            return;
+        }
+        $originalPosition = @ftell($this->stream);
+        if ($this->seekable) {
+            @rewind($this->stream);
+        }
+        $contents = @stream_get_contents($this->stream);
+        if ($contents === false) {
+            $contents = '';
+        }
+        if ($this->seekable && is_int($originalPosition)) {
+            @fseek($this->stream, $originalPosition);
+        }
+        $copy = @fopen('php://temp', 'w+b');
+        if ($copy === false) {
+            return;
+        }
+        if ($contents !== '') {
+            fwrite($copy, $contents);
+        }
+        // Orijinal stream'in pozisyonunu koru
+        if (is_int($originalPosition)) {
+            fseek($copy, $originalPosition);
+        } else {
+            rewind($copy);
+        }
+        $this->stream = $copy;
+        $this->size = strlen($contents);
+        $this->seekable = true;
+        $this->readable = true;
+        $this->writable = true;
+    }
+
+    /**
      * @param null|string|resource|StreamInterface $body
      * @param string|null $target <p>["php://temp"|"php://memory"|NULL]</p>
      * @return StreamInterface
@@ -154,6 +203,15 @@ class Stream implements StreamInterface
                 $body->rewind();
             }
             $body = $body->getContents();
+        }
+        // Resource'lar target'tan bağımsız her zaman kabul edilir
+        if(is_resource($body)){
+            $this->stream = $body;
+            $meta = stream_get_meta_data($this->stream);
+            $this->seekable = $meta['seekable'] && fseek($this->stream, 0, SEEK_CUR) === 0;
+            $this->readable = isset(self::READ_WRITE_HASH['read'][$meta['mode']]);
+            $this->writable = isset(self::READ_WRITE_HASH['write'][$meta['mode']]);
+            return $this;
         }
         if($this->target === null){
             if(!is_scalar($body)){
@@ -176,10 +234,7 @@ class Stream implements StreamInterface
                 fwrite($resource, $body);
                 fseek($resource, 0);
             }
-            $body = $resource;
-        }
-        if(is_resource($body)){
-            $this->stream = $body;
+            $this->stream = $resource;
             $meta = stream_get_meta_data($this->stream);
             $this->seekable = $meta['seekable'] && fseek($this->stream, 0, SEEK_CUR) === 0;
             $this->readable = isset(self::READ_WRITE_HASH['read'][$meta['mode']]);

--- a/src/Message/Traits/MessageTrait.php
+++ b/src/Message/Traits/MessageTrait.php
@@ -154,8 +154,8 @@ trait MessageTrait
             return $this;
         }
 
-        $name = $this->headerNames[$lowercase];
-        unset($this->headerNames[$name], $this->headerNames[$lowercase]);
+        $original = $this->headerNames[$lowercase];
+        unset($this->headers[$original], $this->headerNames[$lowercase]);
 
         return $this;
     }

--- a/src/Message/Traits/RequestTrait.php
+++ b/src/Message/Traits/RequestTrait.php
@@ -22,6 +22,7 @@ use function in_array;
 use function is_string;
 use function preg_match;
 use function strtoupper;
+use function array_map;
 
 trait RequestTrait
 {
@@ -37,7 +38,7 @@ trait RequestTrait
      */
     public function isGet(): bool
     {
-        return $this->getMethod() === 'GET';
+        return strtoupper($this->getMethod()) === 'GET';
     }
 
     /**
@@ -45,7 +46,7 @@ trait RequestTrait
      */
     public function isPost(): bool
     {
-        return $this->getMethod() === 'POST';
+        return strtoupper($this->getMethod()) === 'POST';
     }
 
     /**
@@ -53,7 +54,7 @@ trait RequestTrait
      */
     public function isPut(): bool
     {
-        return $this->getMethod() === 'PUT';
+        return strtoupper($this->getMethod()) === 'PUT';
     }
 
     /**
@@ -61,7 +62,7 @@ trait RequestTrait
      */
     public function isDelete(): bool
     {
-        return $this->getMethod() === 'DELETE';
+        return strtoupper($this->getMethod()) === 'DELETE';
     }
 
     /**
@@ -69,7 +70,7 @@ trait RequestTrait
      */
     public function isHead(): bool
     {
-        return $this->getMethod() === 'HEAD';
+        return strtoupper($this->getMethod()) === 'HEAD';
     }
 
     /**
@@ -77,7 +78,7 @@ trait RequestTrait
      */
     public function isPatch(): bool
     {
-        return $this->getMethod() === 'PATCH';
+        return strtoupper($this->getMethod()) === 'PATCH';
     }
 
     /**
@@ -85,7 +86,7 @@ trait RequestTrait
      */
     public function isMethod(string ...$method): bool
     {
-        return in_array($this->getMethod(), $method);
+        return in_array(strtoupper($this->getMethod()), array_map('strtoupper', $method), true);
     }
 
     /**
@@ -143,7 +144,7 @@ trait RequestTrait
         if(!is_string($method)){
             throw new \InvalidArgumentException('Method must be a string.');
         }
-        $this->method = strtoupper($method);
+        $this->method = $method;
         return $this;
     }
 

--- a/src/Message/Uri.php
+++ b/src/Message/Uri.php
@@ -25,6 +25,8 @@ use function preg_replace_callback;
 use function rawurlencode;
 use function ltrim;
 use function sprintf;
+use function strpos;
+use function preg_replace;
 
 class Uri implements UriInterface
 {
@@ -56,14 +58,16 @@ class Uri implements UriInterface
                 throw new InvalidArgumentException(sprintf('Unable to parse URI: "%s"', $uri));
             }
             $this->scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : '';
-            $this->userInfo = $parts['user'] ?? '';
             $this->host = isset($parts['host']) ? strtolower($parts['host']) : '';
             $this->port = isset($parts['port']) ? $this->filterPort($parts['port']) : null;
             $this->path = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
             $this->query = isset($parts['query']) ? $this->filterQueryAndFragment($parts['query']) : '';
             $this->fragment = isset($parts['fragment']) ? $this->filterQueryAndFragment($parts['fragment']) : '';
-            if (isset($parts['pass'])) {
-                $this->userInfo .= ':' . $parts['pass'];
+            if (isset($parts['user'])) {
+                $this->userInfo = $this->filterUserInfoComponent($parts['user']);
+                if (isset($parts['pass'])) {
+                    $this->userInfo .= ':' . $this->filterUserInfoComponent($parts['pass']);
+                }
             }
         }
     }
@@ -131,6 +135,9 @@ class Uri implements UriInterface
      */
     public function getPath(): string
     {
+        if(isset($this->path[0], $this->path[1]) && $this->path[0] === '/' && $this->path[1] === '/'){
+            return '/' . ltrim($this->path, '/');
+        }
         return $this->path;
     }
 
@@ -180,9 +187,9 @@ class Uri implements UriInterface
      */
     public function setUserInfo(string $user, ?string $password = null): self
     {
-        $info = $user;
+        $info = $this->filterUserInfoComponent($user);
         if ($password !== null && $password !== '') {
-            $info .= ':' . $password;
+            $info .= ':' . $this->filterUserInfoComponent($password);
         }
         if ($this->userInfo === $info) {
             return $this;
@@ -373,6 +380,11 @@ class Uri implements UriInterface
             throw new InvalidArgumentException('Query and fragment must be a string');
         }
         return preg_replace_callback('/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]++|%(?![A-Fa-f0-9]{2}))/', [__CLASS__, 'rawurlencodeMatchZero'], $str);
+    }
+
+    protected function filterUserInfoComponent(string $component): string
+    {
+        return preg_replace_callback('/(?:[^%' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ']+|%(?![A-Fa-f0-9]{2}))/', [__CLASS__, 'rawurlencodeMatchZero'], $component);
     }
 
     protected static function rawurlencodeMatchZero(array $match): string

--- a/tests/Immutability/MessageImmutabilityTest.php
+++ b/tests/Immutability/MessageImmutabilityTest.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Immutability;
+
+use InitPHP\HTTP\Message\Request;
+use InitPHP\HTTP\Message\Response;
+use InitPHP\HTTP\Message\ServerRequest;
+use InitPHP\HTTP\Message\Stream;
+use InitPHP\HTTP\Message\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PSR-7 immutability sözleşmesini sertçe denetler.
+ *
+ * Bu testler eklenmeden önce __clone tanımsız olduğu için Stream ve URI
+ * reference'ları clone'lar arası paylaşılıyordu; "with" mutator'undan dönen
+ * yeni instance üzerinde body'ye yazmak orijinali bozuyordu.
+ */
+final class MessageImmutabilityTest extends TestCase
+{
+    public function testWithHeaderDoesNotShareBodyStream(): void
+    {
+        $request = new Request('GET', '/', [], new Stream('original', 'php://temp'));
+        $clone   = $request->withHeader('X-Test', 'yes');
+
+        $clone->getBody()->write(' tampered');
+
+        self::assertSame('original', (string) $request->getBody(), 'withHeader cloned body must not share state with the original');
+        self::assertStringContainsString('tampered', (string) $clone->getBody());
+    }
+
+    public function testWithMethodDoesNotShareBodyStream(): void
+    {
+        $request = new Request('GET', '/', [], new Stream('keep', 'php://temp'));
+        $clone   = $request->withMethod('POST');
+
+        $clone->getBody()->write(' modified');
+
+        self::assertSame('keep', (string) $request->getBody());
+        self::assertNotSame('keep', (string) $clone->getBody());
+    }
+
+    public function testWithUriDoesNotMutateOriginal(): void
+    {
+        $request = new Request('GET', 'https://a.example/foo');
+        $clone   = $request->withHeader('X-Test', 'yes');
+
+        // PSR-7 ihlali: clone'un URI'sini değiştirmek orijinali değiştirmemeli
+        $clone->getUri()->setHost('attacker.example');
+
+        self::assertSame('a.example', $request->getUri()->getHost());
+        self::assertSame('attacker.example', $clone->getUri()->getHost());
+    }
+
+    public function testResponseWithStatusDoesNotShareBodyStream(): void
+    {
+        // PSR-7 Stream::write current position'a yazar (overwrite, append değil).
+        // Burada doğrulanan tek şey: clone'a yazmak orijinal body'i bozmuyor.
+        $response = new Response(200, [], new Stream('hello', 'php://temp'));
+        $clone    = $response->withStatus(404);
+
+        $clone->getBody()->write('XXXXX');
+
+        self::assertSame('hello', (string) $response->getBody());
+        self::assertNotSame('hello', (string) $clone->getBody());
+    }
+
+    public function testWithHeaderReturnsNewInstance(): void
+    {
+        $request = new Request('GET', '/');
+        $clone   = $request->withHeader('X-Test', 'yes');
+
+        self::assertNotSame($request, $clone);
+        self::assertFalse($request->hasHeader('X-Test'));
+        self::assertTrue($clone->hasHeader('X-Test'));
+    }
+
+    public function testWithoutHeaderActuallyRemovesHeader(): void
+    {
+        // outHeader/withoutHeader bug regresyon koruması
+        $request = (new Request('GET', '/'))->withHeader('Content-Type', 'text/plain');
+        $clone   = $request->withoutHeader('Content-Type');
+
+        self::assertTrue($request->hasHeader('Content-Type'));
+        self::assertFalse($clone->hasHeader('Content-Type'));
+        self::assertSame([], $clone->getHeader('Content-Type'));
+        self::assertArrayNotHasKey('Content-Type', $clone->getHeaders());
+    }
+
+    public function testUriCloneIndependence(): void
+    {
+        $uri   = new Uri('https://example.com:8443/foo');
+        $clone = clone $uri;
+        $clone->setHost('other.example');
+        $clone->setPort(9000);
+
+        self::assertSame('example.com', $uri->getHost());
+        self::assertSame(8443, $uri->getPort());
+        self::assertSame('other.example', $clone->getHost());
+        self::assertSame(9000, $clone->getPort());
+    }
+
+    public function testServerRequestWithAttributeIsImmutable(): void
+    {
+        $request = new ServerRequest('GET', '/');
+        $clone   = $request->withAttribute('user_id', 42);
+
+        self::assertNull($request->getAttribute('user_id'));
+        self::assertSame(42, $clone->getAttribute('user_id'));
+    }
+
+    public function testStreamCloneCopiesContentNotResource(): void
+    {
+        $original = new Stream('seed', 'php://temp');
+        $cloned   = clone $original;
+
+        // İkisi de aynı içeriği görüyor mu? (kopya garantisi)
+        self::assertSame('seed', (string) $original);
+        self::assertSame('seed', (string) $cloned);
+
+        $cloned->write(' extra');
+        self::assertSame('seed', (string) $original, 'Stream clone must not share the underlying resource');
+        self::assertStringContainsString('extra', (string) $cloned);
+    }
+
+    public function testStringBackendStreamCloneIndependence(): void
+    {
+        $original = new Stream('hello', null);
+        $cloned   = clone $original;
+        $cloned->write(' world');
+
+        self::assertSame('hello', (string) $original);
+        self::assertNotSame('hello', (string) $cloned);
+    }
+}

--- a/tests/Psr17/RequestFactoryTest.php
+++ b/tests/Psr17/RequestFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr17;
+
+use InitPHP\HTTP\Factory\Factory;
+use InitPHP\HTTP\Message\Uri;
+use Interop\Http\Factory\RequestFactoryTestCase;
+
+final class RequestFactoryTest extends RequestFactoryTestCase
+{
+    protected function createRequestFactory()
+    {
+        return new Factory();
+    }
+
+    protected function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}

--- a/tests/Psr17/ResponseFactoryTest.php
+++ b/tests/Psr17/ResponseFactoryTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr17;
+
+use InitPHP\HTTP\Factory\Factory;
+use Interop\Http\Factory\ResponseFactoryTestCase;
+
+final class ResponseFactoryTest extends ResponseFactoryTestCase
+{
+    protected function createResponseFactory()
+    {
+        return new Factory();
+    }
+}

--- a/tests/Psr17/ServerRequestFactoryTest.php
+++ b/tests/Psr17/ServerRequestFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr17;
+
+use InitPHP\HTTP\Factory\Factory;
+use InitPHP\HTTP\Message\Uri;
+use Interop\Http\Factory\ServerRequestFactoryTestCase;
+
+final class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
+{
+    protected function createServerRequestFactory()
+    {
+        return new Factory();
+    }
+
+    protected function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}

--- a/tests/Psr17/StreamFactoryTest.php
+++ b/tests/Psr17/StreamFactoryTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr17;
+
+use InitPHP\HTTP\Factory\Factory;
+use Interop\Http\Factory\StreamFactoryTestCase;
+
+final class StreamFactoryTest extends StreamFactoryTestCase
+{
+    protected function createStreamFactory()
+    {
+        return new Factory();
+    }
+}

--- a/tests/Psr17/UploadedFileFactoryTest.php
+++ b/tests/Psr17/UploadedFileFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr17;
+
+use InitPHP\HTTP\Factory\Factory;
+use InitPHP\HTTP\Message\Stream;
+use Interop\Http\Factory\UploadedFileFactoryTestCase;
+
+final class UploadedFileFactoryTest extends UploadedFileFactoryTestCase
+{
+    protected function createUploadedFileFactory()
+    {
+        return new Factory();
+    }
+
+    protected function createStream($content)
+    {
+        return new Stream($content, 'php://temp');
+    }
+}

--- a/tests/Psr17/UriFactoryTest.php
+++ b/tests/Psr17/UriFactoryTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr17;
+
+use InitPHP\HTTP\Factory\Factory;
+use Interop\Http\Factory\UriFactoryTestCase;
+
+final class UriFactoryTest extends UriFactoryTestCase
+{
+    protected function createUriFactory()
+    {
+        return new Factory();
+    }
+}

--- a/tests/Psr18/HttpClientTest.php
+++ b/tests/Psr18/HttpClientTest.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr18;
+
+use InitPHP\HTTP\Client\Client;
+use InitPHP\HTTP\Client\Exceptions\NetworkException;
+use InitPHP\HTTP\Message\Request;
+use InitPHP\HTTP\Message\Stream;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * PSR-18 davranışını kontrollü bir PHP built-in server fixture'ına karşı kapsar.
+ *
+ * Tek-thread/multi-thread macOS uyumsuzlukları nedeniyle php-http/client-integration-tests
+ * paketi yerine yazılmış lokal-ortamda güvenilir koşan smoke testi.
+ */
+final class HttpClientTest extends TestCase
+{
+    private const HOST = '127.0.0.1';
+    private const PORT = 18766;
+
+    /** @var resource */
+    private static $serverProcess;
+    /** @var array */
+    private static $pipes;
+    private static string $baseUrl;
+
+    public static function setUpBeforeClass(): void
+    {
+        $fixture = __DIR__ . '/fixture/server.php';
+        self::$baseUrl = 'http://' . self::HOST . ':' . self::PORT;
+
+        // Önceki çalışmalardan kalan worker'ları temizle
+        self::killPortListeners();
+
+        $cmd = sprintf(
+            'PHP_CLI_SERVER_WORKERS=4 exec php -S %s:%d %s',
+            self::HOST,
+            self::PORT,
+            escapeshellarg($fixture)
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        self::$serverProcess = proc_open($cmd, $descriptors, self::$pipes);
+        if (!is_resource(self::$serverProcess)) {
+            self::fail('Could not start PHP built-in test server.');
+        }
+
+        // Sunucu hazır olana kadar bekle (maks 5 sn)
+        $deadline = microtime(true) + 5.0;
+        while (microtime(true) < $deadline) {
+            $sock = @fsockopen(self::HOST, self::PORT, $errno, $errstr, 0.2);
+            if (is_resource($sock)) {
+                fclose($sock);
+                return;
+            }
+            usleep(50_000);
+        }
+        self::fail('Test server did not become ready in time.');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (is_resource(self::$serverProcess)) {
+            foreach (self::$pipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_terminate(self::$serverProcess, 15);
+            proc_close(self::$serverProcess);
+        }
+        // PHP_CLI_SERVER_WORKERS fork edilmiş worker'ları parent ölünce hayatta kalabilir.
+        // Port üzerinde dinleyen tüm process'leri öldür.
+        self::killPortListeners();
+    }
+
+    private static function killPortListeners(): void
+    {
+        $pidList = @shell_exec(sprintf('lsof -ti tcp:%d 2>/dev/null', self::PORT));
+        if (!is_string($pidList) || trim($pidList) === '') {
+            return;
+        }
+        foreach (preg_split('/\s+/', trim($pidList)) as $pid) {
+            if (ctype_digit($pid)) {
+                @posix_kill((int) $pid, 9);
+            }
+        }
+        usleep(100_000);
+    }
+
+    public function testSendRequestReturnsResponseInterface(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('GET', self::$baseUrl . '/echo'));
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testFourXXResponseIsReturnedNotThrown(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('GET', self::$baseUrl . '/status?code=404'));
+
+        // PSR-18: 4xx ClientException atmaz, response olarak döner
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testFiveXXResponseIsReturnedNotThrown(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('GET', self::$baseUrl . '/status?code=500'));
+
+        // PSR-18: 5xx ClientException atmaz, response olarak döner
+        self::assertSame(500, $response->getStatusCode());
+    }
+
+    public function testNetworkErrorThrowsNetworkExceptionInterface(): void
+    {
+        $client = new Client();
+        $request = new Request('GET', 'http://127.0.0.1:1/'); // unreachable
+
+        try {
+            $client->sendRequest($request);
+            self::fail('Expected NetworkExceptionInterface to be thrown.');
+        } catch (\Throwable $e) {
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertSame($request, $e->getRequest());
+        }
+    }
+
+    public function testHeadersAreSent(): void
+    {
+        $client = new Client();
+        $request = new Request(
+            'GET',
+            self::$baseUrl . '/echo',
+            ['X-Custom' => 'hello', 'X-Multi' => ['a', 'b']]
+        );
+
+        $response = $client->sendRequest($request);
+        $data = json_decode((string) $response->getBody(), true);
+
+        self::assertSame('hello', $data['headers']['x-custom'] ?? null);
+        self::assertSame('a, b', $data['headers']['x-multi'] ?? null);
+    }
+
+    public function testRequestBodyIsTransmittedVerbatim(): void
+    {
+        $client = new Client();
+        $body = '{"name":"safak","n":42}';
+        $request = new Request(
+            'POST',
+            self::$baseUrl . '/echo',
+            ['Content-Type' => 'application/json'],
+            new Stream($body, null)
+        );
+
+        $response = $client->sendRequest($request);
+        $data = json_decode((string) $response->getBody(), true);
+
+        self::assertSame('POST', $data['method']);
+        self::assertSame($body, $data['body']);
+    }
+
+    public function testResponseBodyIsReadable(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('GET', self::$baseUrl . '/echo'));
+
+        $stream = $response->getBody();
+        self::assertTrue($stream->isReadable());
+        // İlk read → ikinci read aynı içerik (Stream->__toString rewind eder)
+        self::assertSame((string) $stream, (string) $stream);
+    }
+
+    public function testSetCookieMultiValueIsPreserved(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('GET', self::$baseUrl . '/cookies'));
+
+        $cookies = $response->getHeader('Set-Cookie');
+        self::assertCount(2, $cookies);
+        self::assertContains('a=1', $cookies);
+        self::assertContains('b=2', $cookies);
+    }
+
+    public function testHeadRequestUsesNoBody(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('HEAD', self::$baseUrl . '/echo'));
+
+        self::assertSame(200, $response->getStatusCode());
+        // HEAD response body PSR-7'ye göre boş olmalı
+        self::assertSame('', (string) $response->getBody());
+    }
+
+    public function testRedirectIsFollowedAndFinalStateReturned(): void
+    {
+        $client = new Client();
+        $response = $client->sendRequest(new Request('GET', self::$baseUrl . '/redirect'));
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertSame('GET', $data['method']);
+    }
+}

--- a/tests/Psr18/fixture/server.php
+++ b/tests/Psr18/fixture/server.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * PSR-18 entegrasyon test fixture'ı.
+ * Route'lar:
+ *   /echo      → method, body ve isteğin header'larını JSON olarak yansıtır
+ *   /status    → ?code=NNN ile arbitrary status döner
+ *   /cookies   → iki Set-Cookie header'ı verir
+ *   /redirect  → 302 ile /echo'a yönlendirir
+ */
+
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/';
+
+if ($path === '/echo') {
+    $headers = [];
+    foreach ($_SERVER as $k => $v) {
+        if (strpos($k, 'HTTP_') === 0) {
+            $headers[strtolower(str_replace('_', '-', substr($k, 5)))] = $v;
+        }
+    }
+    header('Content-Type: application/json');
+    echo json_encode([
+        'method'  => $_SERVER['REQUEST_METHOD'] ?? 'GET',
+        'body'    => file_get_contents('php://input') ?: '',
+        'headers' => $headers,
+        'path'    => $path,
+    ]);
+    return true;
+}
+
+if ($path === '/status') {
+    $code = (int) ($_GET['code'] ?? 200);
+    http_response_code($code);
+    echo 'status ' . $code;
+    return true;
+}
+
+if ($path === '/cookies') {
+    header('Set-Cookie: a=1');
+    header('Set-Cookie: b=2', false);
+    echo 'cookies';
+    return true;
+}
+
+if ($path === '/redirect') {
+    header('Location: /echo', true, 302);
+    echo 'redirecting';
+    return true;
+}
+
+http_response_code(404);
+echo 'not found';
+return true;

--- a/tests/Psr7/RequestTest.php
+++ b/tests/Psr7/RequestTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr7;
+
+use Http\Psr7Test\RequestIntegrationTest;
+use InitPHP\HTTP\Message\Request;
+use InitPHP\HTTP\Message\Stream;
+use InitPHP\HTTP\Message\Uri;
+use Psr\Http\Message\StreamInterface;
+
+final class RequestTest extends RequestIntegrationTest
+{
+    public function createSubject()
+    {
+        return new Request('GET', '/');
+    }
+
+    public function createStream($data)
+    {
+        if ($data instanceof StreamInterface) {
+            return $data;
+        }
+        return new Stream($data, 'php://temp');
+    }
+
+    public function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}

--- a/tests/Psr7/ResponseTest.php
+++ b/tests/Psr7/ResponseTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr7;
+
+use Http\Psr7Test\ResponseIntegrationTest;
+use InitPHP\HTTP\Message\Response;
+use InitPHP\HTTP\Message\Stream;
+use Psr\Http\Message\StreamInterface;
+
+final class ResponseTest extends ResponseIntegrationTest
+{
+    public function createSubject()
+    {
+        return new Response();
+    }
+
+    public function createStream($data)
+    {
+        if ($data instanceof StreamInterface) {
+            return $data;
+        }
+        return new Stream($data, 'php://temp');
+    }
+}

--- a/tests/Psr7/ServerRequestTest.php
+++ b/tests/Psr7/ServerRequestTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr7;
+
+use Http\Psr7Test\ServerRequestIntegrationTest;
+use InitPHP\HTTP\Message\ServerRequest;
+use InitPHP\HTTP\Message\Stream;
+use InitPHP\HTTP\Message\Uri;
+use Psr\Http\Message\StreamInterface;
+
+final class ServerRequestTest extends ServerRequestIntegrationTest
+{
+    public function createSubject()
+    {
+        return (new ServerRequest('GET', '/', [], null, '1.1', $_SERVER))
+            ->setCookieParams($_COOKIE);
+    }
+
+    public function createStream($data)
+    {
+        if ($data instanceof StreamInterface) {
+            return $data;
+        }
+        return new Stream($data, 'php://temp');
+    }
+
+    public function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}

--- a/tests/Psr7/StreamTest.php
+++ b/tests/Psr7/StreamTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr7;
+
+use Http\Psr7Test\StreamIntegrationTest;
+use InitPHP\HTTP\Message\Stream;
+use Psr\Http\Message\StreamInterface;
+
+final class StreamTest extends StreamIntegrationTest
+{
+    public function createStream($data)
+    {
+        if ($data instanceof StreamInterface) {
+            return $data;
+        }
+        return new Stream($data, 'php://temp');
+    }
+}

--- a/tests/Psr7/UploadedFileTest.php
+++ b/tests/Psr7/UploadedFileTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr7;
+
+use Http\Psr7Test\UploadedFileIntegrationTest;
+use InitPHP\HTTP\Message\Stream;
+use InitPHP\HTTP\Message\UploadedFile;
+use Psr\Http\Message\StreamInterface;
+
+final class UploadedFileTest extends UploadedFileIntegrationTest
+{
+    public function createSubject()
+    {
+        return new UploadedFile(new Stream('content', 'php://temp'), 7, \UPLOAD_ERR_OK, 'test.txt', 'text/plain');
+    }
+
+    public function createStream($data)
+    {
+        if ($data instanceof StreamInterface) {
+            return $data;
+        }
+        return new Stream($data, 'php://temp');
+    }
+}

--- a/tests/Psr7/UriTest.php
+++ b/tests/Psr7/UriTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace InitPHP\HTTP\Tests\Psr7;
+
+use Http\Psr7Test\UriIntegrationTest;
+use InitPHP\HTTP\Message\Uri;
+
+final class UriTest extends UriIntegrationTest
+{
+    public function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please:
- Read CONTRIBUTING.md if you haven't: https://github.com/InitPHP/.github/blob/main/CONTRIBUTING.md
- Open one PR per repository — cross-repo changes need a separate PR in each repo, linked in the description.
- Keep the PR focused on one change. If you spotted unrelated improvements, please send them as separate PRs.
-->

## Summary

<!-- One or two sentences: what does this PR do, and why? Focus on the why — the diff already shows the what. -->

## Type of change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behaviour in an incompatible way)
- [ ] 📖 Documentation update
- [ ] 🔧 Refactor / internal change (no behaviour change)
- [ ] ✅ Tests only
- [ ] 🚀 CI / build / tooling

## Linked issues

<!-- e.g. "Closes #123" / "Refs #456" / "Related: InitPHP/HTTP#42" for cross-repo work. -->

## How was this tested?

<!--
Describe the tests you ran and any manual verification steps.
Paste relevant output (test runs, before/after) if helpful.
If this PR adds or changes behaviour, it should also add or update a test.
-->

## Breaking changes

<!--
If you checked "Breaking change" above, describe:
- What breaks (which public API, signature, behaviour)
- The migration path users need to take
- Whether a BC shim (class_alias, deprecation wrapper) was added or considered
Otherwise, write "N/A".
-->

## Checklist

- [ ] Code follows PSR-12 and the project's existing style (PHP-CS-Fixer if available, no warnings)
- [ ] `declare(strict_types=1);` is present in any new PHP files in `src/`
- [ ] Public methods have proper type declarations (parameters and return types)
- [ ] Tests cover the change — added new tests or updated existing ones (N/A for docs-only PRs)
- [ ] PHPStan passes locally at the level configured in the package
- [ ] PHPUnit passes locally (`composer test` or `vendor/bin/phpunit`)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have read and agree to the [Code of Conduct](https://github.com/InitPHP/.github/blob/main/CODE_OF_CONDUCT.md)
